### PR TITLE
fixed GitHub link on the top right corner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -173,7 +173,7 @@ module.exports = {
         //   className: 'persistent',
         // },
         {
-          href: 'https://github.com/Maia-DAO/v2-maia-ecosystem-docs',
+          href: 'https://github.com/Maia-DAO/ecosystem-docs',
           label: 'GitHub',
           position: 'right',
           className: 'persistent',


### PR DESCRIPTION
I have replaced the wrong GitHub link with the correct one on line 176 in docusaurus.config.js file.