### PR TITLE
set respectPrefersColorScheme to false

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -302,7 +302,7 @@ module.exports = {
 
       // Should we use the prefers-color-scheme media-query,
       // using user system preferences, instead of the hardcoded defaultMode
-      respectPrefersColorScheme: true,
+      respectPrefersColorScheme: false,
     },
   },
   presets: [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -173,7 +173,7 @@ module.exports = {
         //   className: 'persistent',
         // },
         {
-          href: 'https://github.com/Maia-DAO/v2-maia-ecosystem-docs',
+          href: 'https://github.com/Maia-DAO/ecosystem-docs',
           label: 'GitHub',
           position: 'right',
           className: 'persistent',


### PR DESCRIPTION
The reason I have set respectPrefersColorScheme to false is because I think the dark theme goes well with the dark-purple theme of Maia/Hermes homepage. It feels more consistent to have darker theme across all of sites. If the a user likes a lighter theme, there is always the switch button on the top right corner.